### PR TITLE
Changed input fields & error logic

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,29 +8,27 @@
     <link rel="stylesheet" href="./assets/styles/styles.css" />
   </head>
   <body>
+    <header>
+      <h1>Money Counter</h1>
+    </header>
     <main>
-      <header>
-        <h1>Money Counter</h1>
-      </header>
-      <div id="tracker-wrapper">
-      </div>
+      <div id="tracker-wrapper"></div>
       <div id="expense-modal" class="hidden">
         <div id="expense-header">
         </div>
         <div id="expense-body">
-          <label for="title-input">Title</label>
-          <input required type="text" id="title-input" class="modal-input" value="" />
-          <br>
-          <label for="amount-input">Amount</label>
-          <input required type="text" id="amount-input" class="modal-input" value="" />
-          <br>
-          <label for="date-input">Date</label>
-          <input required type="date" id="date-input" class="modal-input" value="" />
-          <br>
-          <button type="button" id="expense-submit">Submit</button>
-          <div id="error">
-
-          </div>
+          <form id="expense-form" autocomplete="off">
+            <label for="title-input">Title</label>
+            <input type="text" id="title-input" class="modal-input" value="" autocomplete="one-time-code" required />
+            <br>
+            <label for="amount-input">Amount</label>
+            <input required type="number" id="amount-input" class="modal-input" value="" step="0.01" placeholder="100.00" />
+            <br>
+            <label for="date-input">Date</label>
+            <input required type="date" id="date-input" class="modal-input" value="" />
+            <br>
+            <button type="button" id="expense-submit">Submit</button>
+          </form>
         </div>
       </div>
       <div id="expense-list">

--- a/script.js
+++ b/script.js
@@ -6,7 +6,6 @@ const dateInput = document.getElementById("date-input");
 const expenseList = document.getElementById("expense-list");
 const totalTracker = document.getElementById("tracker-wrapper");
 const submitButton = document.getElementById("expense-submit");
-const errorMsg = document.getElementById("error");
 // exp = expense
 const expData = [];
 // Using Intl class to help format number amounts
@@ -22,16 +21,22 @@ const showModal = () => {
 };
 
 const submitExpense = () => {
-  errorMsg.innerHTML = "";
+  const amountValue = amountInput.value;
 
-  if (!parseFloat(amountInput.value)) {
-    throwError();
+  if (!parseFloat(amountValue)) {
+    alert("Please input a number value for the amount");
     return;
+    
+  } if (Math.floor(amountValue) != amountValue) {
+    if (amountString.split(".")[1].length > 2) {
+      alert("Please input a number with only two decimal spaces");
+      return;
+    }
   }
 
   currentExp = {
     title: titleInput.value,
-    amount: parseFloat(amountInput.value),
+    amount: parseFloat(amountValue),
     date: dateInput.value,
   };
 
@@ -39,6 +44,10 @@ const submitExpense = () => {
   currentExp = {};
   console.log(expData);
   updateList();
+};
+
+const parseDecimal = (float) => {
+  const floatString = float.toString().split(".");
 };
 
 const updateList = () => {
@@ -70,12 +79,6 @@ const updateTotal = () => {
     <p><strong>Total Change:</strong> +${USDollar.format(total)}</p>
     <hr>
   `;
-};
-
-const throwError = (error) => {
-  errorMsg.innerHTML += `<p>Please enter a number for amount</p>`;
-
-  amountInput.value = "";
 };
 
 addExpense.addEventListener("click", showModal);


### PR DESCRIPTION
HTML fields now represent the proper requested data, acting as in-built verification for if an input is in fact a number. Errors will now appear as browser alerts, though this may change again during development. Currently, while HTML inputs are tagged with required and with autocomplete disabled, the testing browser (Firefox) still will allow incomplete forms to be submitted and will still autocomplete from the local cache. Not certain what's causing this yet, but it will be the focus of the next commit.