### PR TITLE
Bugfix/autocomplete

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,15 +19,15 @@
         <div id="expense-body">
           <form id="expense-form" autocomplete="off">
             <label for="title-input">Title</label>
-            <input type="text" id="title-input" class="modal-input" value="" autocomplete="one-time-code" required />
+            <input required type="text" id="title-input" class="modal-input" />
             <br>
             <label for="amount-input">Amount</label>
-            <input required type="number" id="amount-input" class="modal-input" value="" step="0.01" placeholder="100.00" />
+            <input required type="number" id="amount-input" class="modal-input"  step="0.01" placeholder="100.00" />
             <br>
             <label for="date-input">Date</label>
-            <input required type="date" id="date-input" class="modal-input" value="" />
+            <input required type="date" id="date-input" class="modal-input" />
             <br>
-            <button type="button" id="expense-submit">Submit</button>
+            <button type="submit" id="expense-submit">Submit</button>
           </form>
         </div>
       </div>

--- a/script.js
+++ b/script.js
@@ -28,7 +28,7 @@ const submitExpense = () => {
     return;
 
   } if (Math.floor(amountValue) != amountValue) {
-    if (amountString.split(".")[1].length > 2) {
+    if (amountValue.split(".")[1].length > 2) {
       alert("Please input a number with only two decimal spaces");
       return;
     }

--- a/script.js
+++ b/script.js
@@ -18,9 +18,14 @@ let currentExp = {};
 
 const showModal = () => {
   expenseModal.classList.toggle("hidden");
+  // clear inputs whenever the modal is opened
+  titleInput.value = "";
+  amountInput.value = "";
+  dateInput.value = "";
 };
 
-const submitExpense = () => {
+const submitExpense = (event) => {
+  event.preventDefault();
   const amountValue = amountInput.value;
 
   if (!parseFloat(amountValue)) {


### PR DESCRIPTION
Discovered that the testing browser, Firefox, blocks HTML required and autocomplete attributes. To remedy this, added to the showModal function to manually clear each input field on its own. This way, the application shouldn't have to rely on browser support alone. Also fixed some formatting and language, such as changing the submit button into a true submit event, and removing uses of unused variables.